### PR TITLE
Update AlarmDecoder version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     packages=["adext"],
-    install_requires=["alarmdecoder==1.13.2"],
+    install_requires=[
+        "alarmdecoder@https://github.com/nutechsoftware/alarmdecoder/tarball/d45be9f53884ed21a84fb848b18c17fdfcf86170#egg=alarmdecoder-1.13.9b"
+    ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR updates `adext` to use commit https://github.com/nutechsoftware/alarmdecoder/commit/d45be9f53884ed21a84fb848b18c17fdfcf86170 from AlarmDecoder's dev branch.

In addition to updating the AlarmDecoder version from 1.13.2 to 1.13.9, the above commit also includes the [changes here](https://github.com/nutechsoftware/alarmdecoder/compare/1.13.9...d45be9f), which includes fixes for handling new zone faults.