### PR TITLE
Add GitHub Action for automatic PyPI uploads

### DIFF
--- a/.github/workflows/pypi-upload.yaml
+++ b/.github/workflows/pypi-upload.yaml
@@ -1,0 +1,23 @@
+name: pypi-publish
+
+on:
+  release:
+    types: released
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-20.04
+    container: python:3.8
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.release.tag_name }}
+    - name: Install pypa/build
+      run: python -m pip install build --user
+    - name: Build wheel & source tarball
+      run: python -m build --sdist --wheel --outdir dist/ .
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_ADEXT_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Action to enable automatic PyPI uploads any time a GitHub release is released.