### PR TITLE
Use alarmdecoder2 package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     packages=["adext"],
-    install_requires=[
-        "alarmdecoder@https://github.com/nutechsoftware/alarmdecoder/tarball/d45be9f53884ed21a84fb848b18c17fdfcf86170#egg=alarmdecoder-1.13.9b"
-    ],
+    install_requires=["alarmdecoder2==1.13.10rc0"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Continuation of #8. As it turns out, PyPI does not allow uploads of packages that have `install_requires` dependencies that _aren't_ on PyPI. Therefore, I uploaded an [alarmdecoder2](https://pypi.org/project/alarmdecoder2/) package to PyPI which is built from https://github.com/nutechsoftware/alarmdecoder/commit/d45be9f53884ed21a84fb848b18c17fdfcf86170.

This change will be reverted once the AlarmDecoder team publishes an official new release that contains the latest changes.