### PR TITLE
Update AlarmDecoder package to `1.13.11`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     packages=["adext"],
-    install_requires=["alarmdecoder==1.13.10"],
+    install_requires=["alarmdecoder==1.13.11"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR updates the `alarmdecoder` dependency to `1.13.11`.