### PR TITLE
Update `alarmdecoder` package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     packages=["adext"],
-    install_requires=["alarmdecoder==1.13.11"],
+    install_requires=["alarmdecoder==1.13.12"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR updates the `alarmdecoder` package to the latest release: https://pypi.org/project/alarmdecoder/1.13.12/