### PR TITLE
Fix `merge.yaml` branch

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -5,7 +5,7 @@ name: merge
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   merge:


### PR DESCRIPTION
This PR updates the default branch name for the `merge.yaml` workflow that was introduced in #17.