### PR TITLE
Update `alarmdecoder` to `1.13.13`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     packages=["adext"],
-    install_requires=["alarmdecoder==1.13.12"],
+    install_requires=["alarmdecoder==1.13.13"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR updates the `alarmdecoder` package to `1.13.13`: https://github.com/nutechsoftware/alarmdecoder/releases/tag/1.13.13